### PR TITLE
Auth | 2FA

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -55,7 +55,6 @@ export const {
 
       if (existingUser.isTwoFactorEnabled) {
         const twoFactorConfirmation = await getTwoFactorConfirmationByUserId(existingUser.id);
-        console.log({ twoFactorConfirmation: twoFactorConfirmation });
 
         if (!twoFactorConfirmation) {
           return false;

--- a/data/two-factor-confirmation.ts
+++ b/data/two-factor-confirmation.ts
@@ -1,0 +1,12 @@
+import { db } from '@/lib/db';
+
+export const getTwoFactorConfirmationByUserId = async (userId: string) => {
+  try {
+    const twoFactorConfirmation = await db.twoFactorConfirmation.findUnique({
+      where: { userId },
+    });
+    return twoFactorConfirmation;
+  } catch (error) {
+    return null;
+  }
+};

--- a/data/two-factor-token.ts
+++ b/data/two-factor-token.ts
@@ -1,0 +1,23 @@
+import { db } from '@/lib/db';
+
+export const getTwoFactorTokenByToken = async (token: string) => {
+  try {
+    const twoFactorToken = await db.twoFactorToken.findUnique({
+      where: { token },
+    });
+    return twoFactorToken;
+  } catch (error) {
+    return null;
+  }
+};
+
+export const getTwoFactorTokenByEmail = async (email: string) => {
+  try {
+    const twoFactorToken = await db.twoFactorToken.findFirst({
+      where: { email },
+    });
+    return twoFactorToken;
+  } catch (error) {
+    return null;
+  }
+};

--- a/lib/mail.ts
+++ b/lib/mail.ts
@@ -2,11 +2,13 @@ import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
+const fromEmail = 'onboarding@resend.dev';
+
 export const sendPasswordResetEmail = async (email: string, token: string) => {
   const passworddResetLink = `http://localhost:3000/auth/new-password?token=${token}`;
 
   await resend.emails.send({
-    from: 'onboarding@resend.dev',
+    from: fromEmail,
     to: email,
     subject: 'Reset your password',
     html: `<p>Click <a href="${passworddResetLink}">here</a> to reset your password.</p>`,
@@ -17,9 +19,18 @@ export const sendVerificationEmail = async (email: string, token: string) => {
   const confirmLink = `http://localhost:3000/auth/new-verification?token=${token}`;
 
   await resend.emails.send({
-    from: 'onboarding@resend.dev',
+    from: fromEmail,
     to: email,
     subject: 'Confirm your email',
     html: `<p>Click <a href="${confirmLink}">here</a> to confim email.</p>`,
+  });
+};
+
+export const sendTwoFactorEmail = async (email: string, token: string) => {
+  await resend.emails.send({
+    from: fromEmail,
+    to: email,
+    subject: '2FA Code',
+    html: `<p>Here is your 2Fa code: ${token}`,
   });
 };

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,8 +1,10 @@
+import crypto from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '@/lib/db';
 
 import { getVerificationTokenByEmail } from '@/data/verification-token';
 import { getPasswordResetTokenByEmail } from '@/data/password-reset-token';
+import { getTwoFactorTokenByEmail } from '@/data/two-factor-token';
 
 export const generatePasswordResetToken = async (email: string) => {
   const token = uuidv4();
@@ -48,4 +50,28 @@ export const generateVerificationToken = async (email: string) => {
   });
 
   return verificationToken;
+};
+
+export const generateTwoFactorToken = async (email: string) => {
+  const token = crypto.randomInt(100_000, 1_000_000).toString();
+  // TODO Change to 15 minutes for production use
+  const expires = new Date(new Date().getTime() + 3600 * 1000);
+
+  const existingToken = await getTwoFactorTokenByEmail(email);
+  if (existingToken) {
+    await db.twoFactorToken.delete({
+      where: {
+        id: existingToken.id,
+      },
+    });
+  }
+  const twoFactorToken = await db.twoFactorToken.create({
+    data: {
+      token,
+      email,
+      expires,
+    },
+  });
+
+  return twoFactorToken;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,7 @@ export const LoginSchema = z.object({
   password: z.string().min(1, {
     message: 'Password is required',
   }),
+  code: z.optional(z.string()),
 });
 
 export type Login = z.infer<typeof LoginSchema>;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,15 +16,17 @@ enum UserRole {
 }
 
 model User {
-  id            String    @id @default(cuid()) @map("_id")
-  name          String?
-  email         String?   @unique
-  emailVerified DateTime?
-  password      String?
-  role          UserRole  @default(USER)
-  image         String?
-  accounts      Account[]
-  recipes       Recipe[]
+  id                    String                 @id @default(cuid()) @map("_id")
+  name                  String?
+  email                 String?                @unique
+  emailVerified         DateTime?
+  password              String?
+  role                  UserRole               @default(USER)
+  image                 String?
+  accounts              Account[]
+  recipes               Recipe[]
+  isTwoFactorEnabled    Boolean                @default(false)
+  twoFactorConfirmation TwoFactorConfirmation?
 }
 
 model Account {
@@ -62,6 +64,23 @@ model PasswordResetToken {
   expires DateTime
 
   @@unique([email, token])
+}
+
+model TwoFactorToken {
+  id      String   @id @default(cuid()) @map("_id")
+  email   String
+  token   String   @unique
+  expires DateTime
+
+  @@unique([email, token])
+}
+
+model TwoFactorConfirmation {
+  id     String @id @default(cuid()) @map("_id")
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId])
 }
 
 model Recipe {


### PR DESCRIPTION
- added `TwoFactorToken` and `TwoFactorConfirmation` models to `Prisma`
- extended `User` model with a `twoFactorConfirmation` relation property
- added generate and fetch utils for new db models
- added send 2fa email util
- conditionally render `LoginForm` based on 2fa enabled state returned from `login` server action
- extended `signIn` callback to validate 2fa token and confirmation
- extended `login` server action to validate 2fa token and generate confirmation